### PR TITLE
New test for wrong regexps

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -95,6 +95,10 @@ TESTS = {
         {
             "input": "Hello puppy",
             "answer": False
+        },
+        {
+            "input": "Headlamp, wastepaper bin and supermagnificently",
+            "answer": False
         }
     ]
 }


### PR DESCRIPTION
In random review I saw 2 times solution with regexp like r'h\S*e\S*l\S*p'
It may trigger on real English words.
I've added test with 3 of them 
